### PR TITLE
fix(bluesky): pass embed title and description directly

### DIFF
--- a/.github/workflows/bluesky-new-post.yml
+++ b/.github/workflows/bluesky-new-post.yml
@@ -45,6 +45,8 @@ jobs:
 
         ${{ needs.detect.outputs.post_hashtags }}
       embed_url: ${{ needs.detect.outputs.post_url }}
+      embed_title: ${{ needs.detect.outputs.post_title }}
+      embed_description: ${{ needs.detect.outputs.post_description }}
     secrets:
       BLUESKY_USERNAME: ${{ secrets.BLUESKY_USERNAME }}
       BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}


### PR DESCRIPTION
## Summary
- Pass `post_title` and `post_description` from frontmatter directly to the bluesky-post workflow
- Avoids relying on OG tag parsing which was truncating titles at apostrophes

This fixes the issue where "Creating Your Own MSBuild SDK - It's Easier Than You Think!" was appearing as "Creating Your Own MSBuild SDK - It" in the Bluesky embed card.

## Dependencies
- Requires CodingWithCalvin/.github#3 to be merged first

## Test plan
- [ ] Merge CodingWithCalvin/.github#3
- [ ] Merge this PR
- [ ] Next blog post with special characters should display correctly