### PR TITLE
fix(linkedin): add emoji to match Bluesky post format

### DIFF
--- a/.github/workflows/linkedin-new-post.yml
+++ b/.github/workflows/linkedin-new-post.yml
@@ -44,7 +44,7 @@ jobs:
     uses: CodingWithCalvin/.github/.github/workflows/linkedin-post.yml@main
     with:
       post_text: |
-        New Blog Post!
+        📝 New Blog Post!
 
         ${{ needs.detect.outputs.post_title }}
 


### PR DESCRIPTION
Adds 📝 emoji to LinkedIn post text to match Bluesky format.