### PR TITLE
feat(workflows): refactor social posting to use RSS detection

### DIFF
--- a/.github/workflows/bluesky-new-post.yml
+++ b/.github/workflows/bluesky-new-post.yml
@@ -1,11 +1,10 @@
 name: Post New Blog to Bluesky
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'src/content/blog/**'
+  workflow_run:
+    workflows: ["Scheduled Deploy"]
+    types:
+      - completed
   schedule:
     # 8 AM Eastern: 13:00 UTC (EST) / 12:00 UTC (EDT)
     # Using 13:00 UTC = 8 AM EST, 9 AM EDT
@@ -18,34 +17,38 @@ on:
         type: string
 
 jobs:
+  check-trigger:
+    runs-on: ubuntu-latest
+    outputs:
+      should_continue: ${{ steps.check.outputs.should_continue }}
+    steps:
+      - name: Check if we should continue
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_run" ]; then
+            if [ "${{ github.event.workflow_run.conclusion }}" != "success" ]; then
+              echo "Scheduled Deploy failed, skipping"
+              echo "should_continue=false" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+          echo "should_continue=true" >> $GITHUB_OUTPUT
+
   detect:
-    uses: CodingWithCalvin/.github/.github/workflows/detect-new-blog-post.yml@main
+    needs: check-trigger
+    if: needs.check-trigger.outputs.should_continue == 'true'
+    uses: CodingWithCalvin/.github/.github/workflows/detect-blog-post-from-rss.yml@main
     with:
-      content_path: 'src/content/blog'
-      post_filename: 'index.md'
-      site_url: 'https://www.codingwithcalvin.net'
-      url_prefix: ''
-      event_name: ${{ github.event_name }}
-      categories_field: 'categories'
+      rss_url: 'https://www.codingwithcalvin.net/rss.xml'
       target_date: ${{ inputs.target_date }}
 
-  wait-for-deploy:
-    needs: detect
-    if: needs.detect.outputs.has_new_post == 'true' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for Cloudflare deployment
-        run: |
-          echo "Waiting 5 minutes for Cloudflare to deploy..."
-          sleep 300
-
   notify:
-    needs: [detect, wait-for-deploy]
-    if: always() && needs.detect.outputs.has_new_post == 'true' && needs.detect.result == 'success'
+    needs: detect
+    if: needs.detect.outputs.has_posts == 'true'
     uses: CodingWithCalvin/.github/.github/workflows/bluesky-post.yml@main
     with:
       post_text: |
-        📝 New Blog Post!
+        New Blog Post!
 
         [${{ needs.detect.outputs.post_title }}](${{ needs.detect.outputs.post_url }})
 

--- a/.github/workflows/linkedin-new-post.yml
+++ b/.github/workflows/linkedin-new-post.yml
@@ -1,11 +1,10 @@
 name: Post New Blog to LinkedIn
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'src/content/blog/**'
+  workflow_run:
+    workflows: ["Scheduled Deploy"]
+    types:
+      - completed
   schedule:
     # 8:15 AM Eastern (15 min after Bluesky to stagger)
     - cron: '15 13 * * *'
@@ -17,34 +16,38 @@ on:
         type: string
 
 jobs:
+  check-trigger:
+    runs-on: ubuntu-latest
+    outputs:
+      should_continue: ${{ steps.check.outputs.should_continue }}
+    steps:
+      - name: Check if we should continue
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_run" ]; then
+            if [ "${{ github.event.workflow_run.conclusion }}" != "success" ]; then
+              echo "Scheduled Deploy failed, skipping"
+              echo "should_continue=false" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          fi
+          echo "should_continue=true" >> $GITHUB_OUTPUT
+
   detect:
-    uses: CodingWithCalvin/.github/.github/workflows/detect-new-blog-post.yml@main
+    needs: check-trigger
+    if: needs.check-trigger.outputs.should_continue == 'true'
+    uses: CodingWithCalvin/.github/.github/workflows/detect-blog-post-from-rss.yml@main
     with:
-      content_path: 'src/content/blog'
-      post_filename: 'index.md'
-      site_url: 'https://www.codingwithcalvin.net'
-      url_prefix: ''
-      event_name: ${{ github.event_name }}
-      categories_field: 'categories'
+      rss_url: 'https://www.codingwithcalvin.net/rss.xml'
       target_date: ${{ inputs.target_date }}
 
-  wait-for-deploy:
-    needs: detect
-    if: needs.detect.outputs.has_new_post == 'true' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Wait for Cloudflare deployment
-        run: |
-          echo "Waiting 5 minutes for Cloudflare to deploy..."
-          sleep 300
-
   notify:
-    needs: [detect, wait-for-deploy]
-    if: always() && needs.detect.outputs.has_new_post == 'true' && needs.detect.result == 'success'
+    needs: detect
+    if: needs.detect.outputs.has_posts == 'true'
     uses: CodingWithCalvin/.github/.github/workflows/linkedin-post.yml@main
     with:
       post_text: |
-        📝 New Blog Post!
+        New Blog Post!
 
         ${{ needs.detect.outputs.post_title }}
 

--- a/.github/workflows/scheduled-deploy.yml
+++ b/.github/workflows/scheduled-deploy.yml
@@ -1,6 +1,11 @@
 name: Scheduled Deploy
 
 on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/content/blog/**'
   schedule:
     # Run at 7:50 AM Eastern (12:50 UTC) - 10 min before Bluesky post
     - cron: '50 12 * * *'


### PR DESCRIPTION
## Summary

- Add image enclosure to RSS feed for cover images
- Update scheduled-deploy to trigger on blog content push
- Refactor bluesky/linkedin workflows to use workflow_run trigger
- Switch from filesystem to RSS-based post detection
- Remove wait-for-deploy jobs (no longer needed)

## Prerequisites (Manual Steps)

Before merging, disable Cloudflare auto-deploy in the Cloudflare Pages dashboard (Settings > Builds & deployments).

## Dependency

Requires CodingWithCalvin/.github#9 to be merged first.

## Test plan

- [ ] Merge CodingWithCalvin/.github#9 first
- [ ] Disable Cloudflare auto-deploy
- [ ] Merge this PR
- [ ] Test with manual workflow dispatch using a known date

Closes #17