### PR TITLE
fix(workflows): remove exclude_days parameter to use default

### DIFF
--- a/.github/workflows/throwback-thursday.yml
+++ b/.github/workflows/throwback-thursday.yml
@@ -18,7 +18,6 @@ jobs:
     uses: CodingWithCalvin/.github/.github/workflows/random-blog-post-from-rss.yml@main
     with:
       rss_url: 'https://www.codingwithcalvin.net/rss.xml'
-      exclude_days: ${{ inputs.exclude_days || 30 }}
 
   post-bluesky:
     needs: select


### PR DESCRIPTION
## Summary

Remove the `exclude_days` parameter from the throwback workflow call to use the reusable workflow's default (30 days).

The expression `${{ inputs.exclude_days || 30 }}` was causing "Unexpected value '30'" errors due to type coercion issues when passing to a reusable workflow.