### PR TITLE
fix(workflows): expand deploy trigger paths to all site files

### DIFF
--- a/.github/workflows/scheduled-deploy.yml
+++ b/.github/workflows/scheduled-deploy.yml
@@ -5,7 +5,12 @@ on:
     branches:
       - main
     paths:
-      - 'src/content/blog/**'
+      - 'src/**'
+      - 'public/**'
+      - 'astro.config.mjs'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
   schedule:
     # Run at 7:50 AM Eastern (12:50 UTC) - 10 min before Bluesky post
     - cron: '50 12 * * *'


### PR DESCRIPTION
## Summary

Expand the push trigger paths so the site deploys when any Astro-related files change, not just blog content.

**Paths now included:**
- `src/**` - all source files (components, layouts, pages, content)
- `public/**` - static assets
- `astro.config.mjs` - Astro configuration
- `package.json` / `package-lock.json` - dependencies
- `tsconfig.json` - TypeScript configuration