### PR TITLE
feat(blog): enable Giscus commenting system for blog posts

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -66,6 +66,27 @@ const ogImageUrl = image?.src;
           <a href={postUrl} class="text-primary hover:underline">{postUrl}</a>
         </p>
       </blockquote>
+
+      <section class="mt-12">
+        <h2 class="text-2xl font-heading mb-6">Comments</h2>
+        <script
+          src="https://giscus.app/client.js"
+          data-repo="CodingWithCalvin/codingwithcalvin.net"
+          data-repo-id="R_kgDOIdGZXw"
+          data-category="Blog Post Comments"
+          data-category-id="DIC_kwDOIdGZX84C0RR6"
+          data-mapping="og:title"
+          data-strict="1"
+          data-reactions-enabled="1"
+          data-emit-metadata="0"
+          data-input-position="top"
+          data-theme="dark"
+          data-lang="en"
+          data-loading="lazy"
+          crossorigin="anonymous"
+          async
+        ></script>
+      </section>
     </div>
   </article>
 </BaseLayout>

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -67,7 +67,9 @@ const ogImageUrl = image?.src;
         </p>
       </blockquote>
 
-      <section class="mt-12">
+      <hr class="mt-12 border-t border-text-muted/30" />
+
+      <section class="mt-8">
         <h2 class="text-2xl font-heading mb-6">Comments</h2>
         <script
           src="https://giscus.app/client.js"


### PR DESCRIPTION
## Summary
- Adds Giscus commenting system to blog posts using GitHub Discussions
- Comments section appears at the bottom of each post with a visual separator
- Uses `og:title` mapping for discussion threads

Closes #24