### PR TITLE
chore: add editorconfig and license badge

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{ts,tsx,js,jsx}]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+[*.yml]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 👨‍💻 Coding With Calvin
 
+[![License](https://img.shields.io/github/license/CodingWithCalvin/codingwithcalvin.net?style=for-the-badge)](LICENSE)
+
 Personal blog of Calvin Allen — software development thoughts, tutorials, and experiences.
 
 🌐 **Live at:** [codingwithcalvin.net](https://www.codingwithcalvin.net)


### PR DESCRIPTION
## Summary
- Add .editorconfig for TypeScript/Astro projects with 2-space indentation
- Add license badge to README

## Test plan
- [ ] Verify .editorconfig is applied by IDE
- [ ] Verify badge renders correctly in README