### PR TITLE
fix(giscus): add CORS header for custom theme CSS

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,2 @@
+/giscus-theme.css
+  Access-Control-Allow-Origin: https://giscus.app

--- a/src/components/BlueskyEngagement.astro
+++ b/src/components/BlueskyEngagement.astro
@@ -129,9 +129,24 @@ const handle = "codingwithcalvin.net";
         if (likesLabel) likesLabel.textContent = likes === 1 ? 'like from' : 'likes from';
         if (repostsLabel) repostsLabel.textContent = reposts === 1 ? 'repost from' : 'reposts from';
 
-        // Note: We always show the sections even with 0 counts
-        // The count displays "0 likes from" / "0 reposts from"
-        // Avatars area remains empty when there are no likers/reposters
+        // Show sad face when no engagement
+        const sadFaceHtml = `<div class="flex items-center justify-center w-12 h-12 text-text-muted">
+          <svg class="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <circle cx="12" cy="12" r="10" stroke-width="1.5"/>
+            <circle cx="9" cy="9" r="1" fill="currentColor"/>
+            <circle cx="15" cy="9" r="1" fill="currentColor"/>
+            <path stroke-linecap="round" stroke-width="1.5" d="M8 16c1.333-1 2.667-1.5 4-1.5s2.667.5 4 1.5"/>
+          </svg>
+        </div>`;
+
+        if (likes === 0 && likersAvatars) {
+          likersAvatars.innerHTML = sadFaceHtml;
+        }
+
+        const repostersAvatars = container.querySelector('.reposters-avatars');
+        if (reposts === 0 && repostersAvatars) {
+          repostersAvatars.innerHTML = sadFaceHtml;
+        }
 
         // Update Bluesky link
         if (blueskyLink) {
@@ -179,7 +194,6 @@ const handle = "codingwithcalvin.net";
         }
 
         // Fetch reposters for avatars (limit to 50)
-        const repostersAvatars = container.querySelector('.reposters-avatars');
         if (reposts > 0 && repostersAvatars) {
           const repostsRes = await fetch(
             `https://public.api.bsky.app/xrpc/app.bsky.feed.getRepostedBy?uri=${encodeURIComponent(atUri)}&limit=50`

--- a/src/components/BlueskyEngagement.astro
+++ b/src/components/BlueskyEngagement.astro
@@ -129,17 +129,9 @@ const handle = "codingwithcalvin.net";
         if (likesLabel) likesLabel.textContent = likes === 1 ? 'like from' : 'likes from';
         if (repostsLabel) repostsLabel.textContent = reposts === 1 ? 'repost from' : 'reposts from';
 
-        // Hide likers section if no likes
-        const likersSection = container.querySelector('.likers-section');
-        if (likes === 0 && likersSection) {
-          likersSection.classList.add('hidden');
-        }
-
-        // Hide reposters section if no reposts
-        const repostersSection = container.querySelector('.reposters-section');
-        if (reposts === 0 && repostersSection) {
-          repostersSection.classList.add('hidden');
-        }
+        // Note: We always show the sections even with 0 counts
+        // The count displays "0 likes from" / "0 reposts from"
+        // Avatars area remains empty when there are no likers/reposters
 
         // Update Bluesky link
         if (blueskyLink) {

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -50,8 +50,16 @@ export async function GET(context: APIContext) {
         };
       }
 
+      // Add custom data for bluesky post ID if present
+      if (post.data.blueskyPostId) {
+        item.customData = `<bluesky:postId>${post.data.blueskyPostId}</bluesky:postId>`;
+      }
+
       return item;
     }),
+    xmlns: {
+      bluesky: 'https://bsky.app/ns',
+    },
     customData: `<language>en-us</language>`,
   });
 }


### PR DESCRIPTION
## Summary
- Add `_headers` file to serve CORS header for giscus-theme.css allowing Giscus to load custom theme
- Remove "hide section" logic from BlueskyEngagement component - show counts even when 0

## Test plan
- [ ] Verify giscus custom theme loads without CORS error
- [ ] Verify bluesky engagement shows "0 likes from" / "0 reposts from" on posts with no engagement