### PR TITLE
fix(workflow): add history tracking to prevent duplicate throwback posts

### DIFF
--- a/.github/workflows/bluesky-new-post.yml
+++ b/.github/workflows/bluesky-new-post.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Checkout blog repo
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CONTRIBUTORS_TOKEN }}
 
       - name: Find and update blog post
         run: |

--- a/.github/workflows/throwback-thursday.yml
+++ b/.github/workflows/throwback-thursday.yml
@@ -14,7 +14,7 @@ jobs:
       rss_url: 'https://www.codingwithcalvin.net/rss.xml'
       history_variable_name: 'THROWBACK_HISTORY'
     secrets:
-      HISTORY_TOKEN: ${{ secrets.HISTORY_PAT }}
+      HISTORY_TOKEN: ${{ secrets.CONTRIBUTORS_TOKEN }}
 
   post-bluesky:
     needs: select

--- a/.github/workflows/throwback-thursday.yml
+++ b/.github/workflows/throwback-thursday.yml
@@ -12,6 +12,9 @@ jobs:
     uses: CodingWithCalvin/.github/.github/workflows/random-blog-post-from-rss.yml@main
     with:
       rss_url: 'https://www.codingwithcalvin.net/rss.xml'
+      history_variable_name: 'THROWBACK_HISTORY'
+    secrets:
+      HISTORY_TOKEN: ${{ secrets.HISTORY_PAT }}
 
   post-bluesky:
     needs: select


### PR DESCRIPTION
## Summary
- Pass `history_variable_name: 'THROWBACK_HISTORY'` to track selected posts
- Pass `HISTORY_PAT` secret for repository variable API access
- Prevents the same post from being selected twice within 2 years (104 weeks)

## Dependencies
- Requires https://github.com/CodingWithCalvin/.github/pull/45 to be merged first

## Test plan
- [ ] Merge the .github PR first
- [ ] Create fine-grained PAT with Variables read/write permission for this repo
- [ ] Add `HISTORY_PAT` secret to this repo
- [ ] Merge this PR
- [ ] Trigger throwback-thursday workflow via workflow_dispatch
- [ ] Verify `THROWBACK_HISTORY` variable is created with the selected URL
- [ ] Trigger again and verify a different post is selected