### PR TITLE
feat(rss): include cover images as enclosures

### DIFF
--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -3,6 +3,7 @@ import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
 import sanitizeHtml from 'sanitize-html';
 import MarkdownIt from 'markdown-it';
+import { getPostImage } from '../lib/posts';
 
 const parser = new MarkdownIt();
 
@@ -49,13 +50,12 @@ export async function GET(context: APIContext) {
         }),
       };
 
-      if (post.data.image) {
-        item.enclosure = {
-          url: `${site}${post.data.image.src}`,
-          type: getMimeType(post.data.image.src),
-          length: 0,
-        };
-      }
+      const image = getPostImage(post);
+      item.enclosure = {
+        url: `${site}${image.src}`,
+        type: getMimeType(image.src),
+        length: 0,
+      };
 
       // Add custom data for bluesky post ID if present
       if (post.data.blueskyPostId) {


### PR DESCRIPTION
## Summary
- Use `getPostImage` to resolve cover images for each post
- Include cover images as RSS enclosure elements
- Falls back to default cover if no custom `cover.png` exists

## Test plan
- [x] Build completes successfully
- [x] RSS feed includes `<enclosure>` elements with cover image URLs
- [ ] Verify cover images appear in RSS readers that support enclosures