### PR TITLE
perf(images): use webp format and 80% quality for embedded images

### DIFF
--- a/src/components/PostCard.astro
+++ b/src/components/PostCard.astro
@@ -30,8 +30,8 @@ const formattedDate = date.toLocaleDateString('en-US', {
         alt={title}
         width={1920}
         height={1080}
-        quality={100}
-        format="png"
+        quality={80}
+        format="webp"
         class="w-full h-full object-cover hover:scale-105 transition-transform duration-300"
         loading="lazy"
       />

--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -58,6 +58,8 @@ const ogImageUrl = image?.src;
           <Image
             src={image}
             alt={title}
+            quality={80}
+            format="webp"
             class="w-full"
           />
         </div>


### PR DESCRIPTION
## Summary
- Updates PostCard and PostLayout Image components to use webp format
- Sets quality to 80% instead of 100%
- Significantly reduces file sizes for displayed images
- Original images remain at full quality for lightbox viewing

## Changes
- `PostCard.astro`: Changed from `quality={100} format="png"` to `quality={80} format="webp"`
- `PostLayout.astro`: Added `quality={80} format="webp"` to cover image

## Test plan
- [ ] Build the site and compare output sizes
- [ ] Verify images still look good at 80% quality
- [ ] Confirm lightbox still shows full-quality originals