### PR TITLE
fix(ci): pass image URL to bluesky workflow to avoid OG fetch timeout

### DIFF
--- a/.github/workflows/bluesky-new-post.yml
+++ b/.github/workflows/bluesky-new-post.yml
@@ -56,6 +56,7 @@ jobs:
       embed_url: ${{ needs.detect.outputs.post_url }}
       embed_title: ${{ needs.detect.outputs.post_title }}
       embed_description: ${{ needs.detect.outputs.post_description }}
+      embed_image_url: ${{ needs.detect.outputs.post_image_url }}
     secrets:
       BLUESKY_USERNAME: ${{ secrets.BLUESKY_USERNAME }}
       BLUESKY_APP_PASSWORD: ${{ secrets.BLUESKY_APP_PASSWORD }}


### PR DESCRIPTION
## Summary
Passes `embed_image_url` from the RSS feed detection to the Bluesky post workflow, avoiding the need to fetch OG tags from the live site.

## Problem
The workflow was timing out when fetching OG tags because the site hadn't fully propagated after deploy.

## Solution
The detect workflow already extracts `post_image_url` from RSS. The bluesky-post reusable workflow skips OG fetching when both `embed_title` and `embed_image_url` are provided.

## Test plan
- [ ] Trigger workflow manually and verify no OG fetch timeout
- [ ] Confirm Bluesky post includes the cover image