### PR TITLE
fix(blog): use CSS-based icons for lightbox buttons

### DIFF
--- a/src/layouts/PostLayout.astro
+++ b/src/layouts/PostLayout.astro
@@ -100,12 +100,12 @@ const year = date.getFullYear();
             <span class="lightbox-title">Full-size image</span>
             <span class="lightbox-hint">Click outside or press Esc to close</span>
           </div>
-          <button class="lightbox-nav lightbox-prev" aria-label="Previous image">&#8249;</button>
+          <button class="lightbox-nav lightbox-prev" aria-label="Previous image"></button>
           <div class="lightbox-container">
             <img src="" alt="" />
           </div>
-          <button class="lightbox-nav lightbox-next" aria-label="Next image">&#8250;</button>
-          <button class="lightbox-close" aria-label="Close">&times;</button>
+          <button class="lightbox-nav lightbox-next" aria-label="Next image"></button>
+          <button class="lightbox-close" aria-label="Close"></button>
           <div class="lightbox-footer">
             <span class="lightbox-counter"></span>
           </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -183,8 +183,7 @@ code {
   right: 1rem;
   background: var(--color-primary);
   border: none;
-  color: white;
-  font-size: 1.5rem;
+  font-size: 0;
   width: 2.5rem;
   height: 2.5rem;
   border-radius: 50%;
@@ -194,6 +193,24 @@ code {
   justify-content: center;
   transition: background 0.2s ease, transform 0.2s ease;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.lightbox-close::before,
+.lightbox-close::after {
+  content: '';
+  position: absolute;
+  width: 1.1rem;
+  height: 2.5px;
+  background: white;
+  border-radius: 1px;
+}
+
+.lightbox-close::before {
+  transform: rotate(45deg);
+}
+
+.lightbox-close::after {
+  transform: rotate(-45deg);
 }
 
 .lightbox-close:hover {
@@ -227,7 +244,7 @@ code {
   background: var(--color-primary);
   border: none;
   color: white;
-  font-size: 2rem;
+  font-size: 0;
   width: 3rem;
   height: 3rem;
   border-radius: 50%;
@@ -238,6 +255,25 @@ code {
   transition: background 0.2s ease, transform 0.2s ease, opacity 0.2s ease;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
   z-index: 10;
+}
+
+.lightbox-nav::before {
+  content: '';
+  display: block;
+  width: 0.6rem;
+  height: 0.6rem;
+  border-top: 2.5px solid white;
+  border-right: 2.5px solid white;
+}
+
+.lightbox-prev::before {
+  transform: rotate(-135deg);
+  margin-left: 0.2rem;
+}
+
+.lightbox-next::before {
+  transform: rotate(45deg);
+  margin-right: 0.2rem;
 }
 
 .lightbox-nav:hover:not(.disabled) {


### PR DESCRIPTION
## Summary
- Replace font characters (‹ › ×) with CSS-generated shapes for lightbox buttons
- Navigation arrows use rotated bordered squares (chevrons)
- Close button uses two rotated lines forming an X
- Icons now stay perfectly centered, including on hover

## Test plan
- [ ] Open lightbox on a blog post with images
- [ ] Verify prev/next arrows are centered in their buttons
- [ ] Verify close X is centered in its button
- [ ] Hover over each button and confirm icons remain centered