### PR TITLE
ci(workflow): remove social media reference from schedule comment

### DIFF
--- a/.github/workflows/scheduled-deploy.yml
+++ b/.github/workflows/scheduled-deploy.yml
@@ -12,7 +12,7 @@ on:
       - 'package-lock.json'
       - 'tsconfig.json'
   schedule:
-    # Run at 7:50 AM Eastern (12:50 UTC) - 10 min before Bluesky post
+    # Run at 7:50 AM Eastern (12:50 UTC)
     - cron: '50 12 * * *'
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Remove reference to Bluesky posting from the schedule comment in scheduled-deploy.yml

## Test plan
- [ ] No functional changes, comment-only update